### PR TITLE
게시글 상세 페이지 (/recruitments/:id) api 연동 (1/2)

### DIFF
--- a/frontend/src/components/hooks/useRecruitment.js
+++ b/frontend/src/components/hooks/useRecruitment.js
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+import { authFetcher } from "utils/axios";
+
+function useRecruitment(id) {
+  const { data, error, mutate } = useSWR(id ? `/projects/${id}` : null, authFetcher);
+
+  return {
+    data,
+    error,
+    loading: !data && !error,
+    mutate,
+  };
+}
+
+export default useRecruitment;

--- a/frontend/src/components/pages/home/sections/RecentProjectsSection.js
+++ b/frontend/src/components/pages/home/sections/RecentProjectsSection.js
@@ -8,7 +8,6 @@ function RecentProjectsSection() {
   const { recruitments, size, setSize, initialLoading, loadingMore, empty, reachingEnd } =
     useRecruitments({
       pageSize: PAGE_SIZE,
-      sortBy: "favorite.desc",
     });
 
   return (

--- a/frontend/src/components/pages/login/sections/LoginSection.js
+++ b/frontend/src/components/pages/login/sections/LoginSection.js
@@ -2,6 +2,7 @@ import { Button, Container, Flex, Input, FormControl, FormLabel, useToast } from
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { serverAxios } from "utils/axios";
+import { setCookie } from "utils/cookie";
 
 function LoginSection() {
   const { register, handleSubmit } = useForm();
@@ -16,7 +17,7 @@ function LoginSection() {
 
       if (res.data.success) {
         toast.closeAll();
-        document.cookie = `jwt=${res.data.token};`;
+        setCookie("jwt", res.data.token);
         window.location = "/";
       } else {
         toast({

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -16,10 +16,12 @@ import {
   VStack,
   Wrap,
 } from "@chakra-ui/react";
-import { MOCKUP_PROJECT } from "constants/mockups/project";
+import useMe from "components/hooks/useMe";
+import useRecruitment from "components/hooks/useRecruitment";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter } from "next/router";
+import defaultUserImage from "/public/images/default-user-image.png";
 
 const InfoTitle = chakra(Text, {
   baseStyle: {
@@ -38,10 +40,13 @@ const InfoText = chakra(InfoTitle, {
 });
 
 function RecruitmentDetailSection() {
-  const [data, setData] = useState(MOCKUP_PROJECT);
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [mine, setMine] = useState(false);
+  const router = useRouter();
 
+  const { data, loading } = useRecruitment(router.query.id);
+  const { loggedIn, user } = useMe();
+  const mine = user?.userId === data?.author.id ?? false;
+
+  if (loading) return "loading...";
   return (
     <Box as="section" marginTop="80px">
       <Container as="article" maxW="container.lg" paddingY="80px">
@@ -92,7 +97,7 @@ function RecruitmentDetailSection() {
             <VStack spacing="30px" w="100%" align="flex-start">
               <Link href={`/users/${data.author.id}`} passHref>
                 <HStack as="a" spacing="16px">
-                  <Avatar size="md" src={data.author.photoUrl} />
+                  <Avatar size="md" src={data.author.photoUrl ?? defaultUserImage.src} />
                   <Text fontSize="20px" color="gray.700" fontWeight="bold">
                     {data.author.name}
                   </Text>
@@ -139,9 +144,16 @@ function RecruitmentDetailSection() {
 
           <Divider />
 
-          <Box w="100%" h="420px" position="relative">
-            <Image src={data.photoUrl} alt="게시글 대표 이미지" layout="fill" objectFit="contain" />
-          </Box>
+          {data.photoUrl && (
+            <Box w="100%" h="420px" position="relative">
+              <Image
+                src={data.photoUrl}
+                alt="게시글 대표 이미지"
+                layout="fill"
+                objectFit="contain"
+              />
+            </Box>
+          )}
 
           <Box w="100%">{data.content}</Box>
 

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -11,8 +11,16 @@ import {
   Heading,
   HStack,
   IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
   Tag,
   Text,
+  useDisclosure,
   VStack,
   Wrap,
 } from "@chakra-ui/react";
@@ -21,6 +29,9 @@ import useRecruitment from "components/hooks/useRecruitment";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useCallback } from "react";
+import { getAuthHeader } from "utils/auth";
+import { serverAxios } from "utils/axios";
 import defaultUserImage from "/public/images/default-user-image.png";
 
 const InfoTitle = chakra(Text, {
@@ -41,6 +52,17 @@ const InfoText = chakra(InfoTitle, {
 
 function RecruitmentDetailSection() {
   const router = useRouter();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleClickDeleteButton = useCallback(async () => {
+    try {
+      await serverAxios.delete(`/projects/${router.query.id}`, getAuthHeader());
+      router.push("/");
+    } catch (e) {
+      console.log(e);
+    }
+  }, [router]);
 
   const { data, loading } = useRecruitment(router.query.id);
   const { loggedIn, user } = useMe();
@@ -71,7 +93,28 @@ function RecruitmentDetailSection() {
                     <Button colorScheme="gray" variant="outline">
                       수정
                     </Button>
-                    <Button colorScheme="red">삭제</Button>
+                    <Button colorScheme="red" onClick={onOpen}>
+                      삭제
+                    </Button>
+
+                    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+                      <ModalOverlay />
+                      <ModalContent>
+                        <ModalHeader>정말 삭제하시겠습니까?</ModalHeader>
+                        <ModalCloseButton />
+                        <ModalBody>삭제한 게시글은 되돌릴 수 없습니다.</ModalBody>
+                        <ModalFooter>
+                          <HStack spacing="8px">
+                            <Button colorScheme="gray" onClick={onClose}>
+                              취소
+                            </Button>
+                            <Button colorScheme="red" onClick={handleClickDeleteButton}>
+                              삭제
+                            </Button>
+                          </HStack>
+                        </ModalFooter>
+                      </ModalContent>
+                    </Modal>
                   </HStack>
                 ) : (
                   <Button colorScheme="gray" variant="outline">


### PR DESCRIPTION
## 작업 내용

- 게시글 상세 페이지 API 연동 작업
  - 게시글 정보
  - 본인 게시글 판별 및 로그인 상태 판별
  - 게시글 삭제

- 남은 작업
  - 게시글 수정
  - 신청자 확인
  - 즐겨찾기
  - 신청하기

## 체크 리스트

- [x] 제목을 적절히 작성했나요?
- [x] 라벨을 알맞게 설정했나요?
