### PR TITLE
백엔드 오류 수정 및 게시글 등록 시 id 반환 기능 추가 / 프론트엔드 게시글 작성 및 수정 기능 구현

### DIFF
--- a/backend/models/project.js
+++ b/backend/models/project.js
@@ -57,7 +57,7 @@ module.exports = function(sequelize) {
         },
         image:{
             field: 'image',
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(10000),
             allowNull: true,
         },
         message:{

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -56,7 +56,7 @@ module.exports = function(sequelize) {
         },
         image:{
             field: 'image',
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(10000),
             allowNull: true,
         }
     }, {

--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -369,7 +369,7 @@ router.post('/', uploadProject.single('photoUrl'), async function(req, res) {
             };
             
             await db.Project.create(projectInfo).then( result => {
-                return res.status(201).json({"success":true, "reason": "프로젝트를 성공적으로 등록했습니다."});
+                return res.status(201).json({"success":true, "reason": "프로젝트를 성공적으로 등록했습니다.", "projectId": result.dataValues.projectId});
             }).catch(err => {
                 return res.status(500).json({"success": false, "reason": "시스템 오류가 발생했습니다. 다시 시도해주세요"});
             });

--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -689,7 +689,7 @@ router.post('/:id', uploadProject.single('photoUrl'), async function(req, res) {
 
                 // 프로젝트 연락 수단을 변경하는 경우
                 if(req.body.contactMethod || req.body.contactValue){
-                    let contact = body.contactMethod + '#' + body.contactValue;
+                    let contact = req.body.contactMethod + '#' + req.body.contactValue;
                     await db.Project.update({message: contact},{where:{projectId: project.dataValues.projectId}});
                 }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-}
 
-module.exports = nextConfig
+  images: {
+    domains: ["2022fall-42class-team12.s3.ap-northeast-2.amazonaws.com"],
+  },
+};
+
+module.exports = nextConfig;

--- a/frontend/src/components/common/SkillInput.js
+++ b/frontend/src/components/common/SkillInput.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import { Button, FormControl, FormLabel, HStack, Input, VStack, Wrap } from "@chakra-ui/react";
 import EditableTag from "components/common/EditableTag";
 import { useEffect, useRef, useState } from "react";
@@ -21,12 +20,12 @@ function SkillInput({ value = [], onChange, ...props }) {
   };
 
   useEffect(() => {
-    onChange?.(skills);
-  }, [onChange, skills]);
-
-  useEffect(() => {
     setSkills(value);
   }, [value]);
+
+  useEffect(() => {
+    onChange?.(skills);
+  }, [onChange, skills]);
 
   return (
     <VStack spacing="20px" {...props}>

--- a/frontend/src/components/common/SkillInput.js
+++ b/frontend/src/components/common/SkillInput.js
@@ -3,8 +3,8 @@ import { Button, FormControl, FormLabel, HStack, Input, VStack, Wrap } from "@ch
 import EditableTag from "components/common/EditableTag";
 import { useEffect, useRef, useState } from "react";
 
-function SkillInput({ onChange, ...props }) {
-  const [skills, setSkills] = useState([]);
+function SkillInput({ value = [], onChange, ...props }) {
+  const [skills, setSkills] = useState(value);
   const skillInputRef = useRef(null);
   const handleSkillsInput = () => {
     if (!skillInputRef.current) {
@@ -23,6 +23,10 @@ function SkillInput({ onChange, ...props }) {
   useEffect(() => {
     onChange?.(skills);
   }, [onChange, skills]);
+
+  useEffect(() => {
+    setSkills(value);
+  }, [value]);
 
   return (
     <VStack spacing="20px" {...props}>

--- a/frontend/src/components/common/SkillInput.js
+++ b/frontend/src/components/common/SkillInput.js
@@ -3,7 +3,7 @@ import { Button, FormControl, FormLabel, HStack, Input, VStack, Wrap } from "@ch
 import EditableTag from "components/common/EditableTag";
 import { useEffect, useRef, useState } from "react";
 
-function SkillInput({ onChange }) {
+function SkillInput({ onChange, ...props }) {
   const [skills, setSkills] = useState([]);
   const skillInputRef = useRef(null);
   const handleSkillsInput = () => {
@@ -25,8 +25,8 @@ function SkillInput({ onChange }) {
   }, [onChange, skills]);
 
   return (
-    <VStack spacing="20px">
-      <HStack w="100%" align="flex-end">
+    <VStack spacing="20px" {...props}>
+      <HStack w="100%" align="flex-end" spacing="16px">
         <FormControl>
           <FormLabel>기술 스택</FormLabel>
           <Input
@@ -35,7 +35,9 @@ function SkillInput({ onChange }) {
             bg="white"
           />
         </FormControl>
-        <Button onClick={handleSkillsInput}>추가</Button>
+        <Button onClick={handleSkillsInput} w="30%">
+          추가
+        </Button>
       </HStack>
 
       <Wrap w="100%" overflow="visible">

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -90,9 +90,11 @@ function RecruitmentDetailSection() {
               {loggedIn ? (
                 mine ? (
                   <HStack spacing="8px">
-                    <Button colorScheme="gray" variant="outline">
-                      수정
-                    </Button>
+                    <Link href={`/recruitments/write?id=${router.query.id}`} passHref>
+                      <Button as="a" colorScheme="gray" variant="outline">
+                        수정
+                      </Button>
+                    </Link>
                     <Button colorScheme="red" onClick={onOpen}>
                       삭제
                     </Button>

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -198,7 +198,9 @@ function RecruitmentDetailSection() {
             </Box>
           )}
 
-          <Box w="100%">{data.content}</Box>
+          <Box w="100%" whiteSpace="pre">
+            {data.content}
+          </Box>
 
           {loggedIn ? (
             mine ? (

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentWriteSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentWriteSection.js
@@ -44,7 +44,7 @@ function RecruitmentWriteSection() {
     };
 
     try {
-      let createdId;
+      let targetId;
       let toastMessage;
       if (router.query.id) {
         await serverAxios.post(`/projects/${router.query.id}`, reqBody, {
@@ -53,7 +53,7 @@ function RecruitmentWriteSection() {
             Authorization: `Bearer ${getCookie("jwt")}`,
           },
         });
-        createdId = router.query.id;
+        targetId = router.query.id;
         toastMessage = "모집글이 수정되었습니다.";
       } else {
         const { data } = await serverAxios.post("/projects", reqBody, {
@@ -62,7 +62,7 @@ function RecruitmentWriteSection() {
             Authorization: `Bearer ${getCookie("jwt")}`,
           },
         });
-        // createdId = data.id;
+        targetId = data.projectId;
         toastMessage = "모집글이 등록되었습니다.";
       }
       toast.closeAll();
@@ -72,7 +72,7 @@ function RecruitmentWriteSection() {
         isClosable: true,
       });
       // TODO: 백엔드에서 등록된 글 id 리턴해주면 글 링크로 이동
-      Router.push(`/`);
+      Router.push(`/recruitments/${targetId}`);
     } catch (e) {
       toast({
         title: "모집글 등록 실패",

--- a/frontend/src/components/pages/register/PersonalInfoFormGroup.js
+++ b/frontend/src/components/pages/register/PersonalInfoFormGroup.js
@@ -8,12 +8,14 @@ import {
   FormHelperText,
 } from "@chakra-ui/react";
 import SkillInput from "components/common/SkillInput";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 function PersonalInfoFormGroup() {
   const { register, setValue } = useFormContext();
 
   register("skills", { required: true });
+  const [skills, setSkills] = useState([]);
 
   return (
     <Flex direction="column" w="100%">
@@ -87,7 +89,9 @@ function PersonalInfoFormGroup() {
       </FormControl>
 
       <SkillInput
+        value={skills}
         onChange={(skills) => {
+          setSkills(skills);
           setValue("skills", skills);
         }}
       />


### PR DESCRIPTION
## 작업 내용

### 백엔드
#### 버그
- 유저 및 프로젝트의 image 필드 length 제한으로 인해 파일 이름이 길어지면 터지는 현상 해결 (10000으로 넉넉하게 줌)
- 프로젝트 수정(POST /projects/:id) 에서 변수명으로 인한 버그 수정

#### 기능
- 프로젝트 정상 등록 시 등록된 id 반환하도록 함

### 프론트엔드
- 게시글 작성 기능 구현
- 게시글 수정 기능 구현

## 체크 리스트

- [x] 제목을 적절히 작성했나요?
- [x] 라벨을 알맞게 설정했나요?
