### PR TITLE
User image field length가 너무 길었던 현상 수정

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -56,7 +56,7 @@ module.exports = function(sequelize) {
         },
         image:{
             field: 'image',
-            type: DataTypes.STRING(10000),
+            type: DataTypes.STRING(5000),
             allowNull: true,
         }
     }, {


### PR DESCRIPTION
## 작업 내용

이전 PR에서 user image field length를 10000으로 늘렸더니 터져서 5000으로 줄입니다. 확인을 미처 못했네요 ㅠ

## 체크 리스트

- [x] 제목을 적절히 작성했나요?
- [x] 라벨을 알맞게 설정했나요?
