### PR TITLE
즐겨찾기 및 신청하기, 신청자 관리 기능 구현

### DIFF
--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -800,10 +800,11 @@ router.delete('/:id/favorite', async function(req, res) {
 
         // 즐겨찾기 테이블에서 삭제
         await db.Star.destroy({
-            where: {projectId: req.params.id, user: identity.userId}
+            where: {project: req.params.id, user: identity.userId}
         }).then( result => {
             return res.status(200).json({"success":true, "reason": "즐겨찾기에서 삭제했습니다."});
         }).catch(err => {
+            console.log(err)
             return res.status(500).json({"success": false, "reason": "시스템 오류가 발생했습니다. 다시 시도해주세요"});
         });
 

--- a/frontend/src/components/hooks/useApplication.js
+++ b/frontend/src/components/hooks/useApplication.js
@@ -1,0 +1,19 @@
+import useSWR from "swr";
+import { authFetcher } from "utils/axios";
+
+// NOTE: 페이지네이션 적용할 것이라면 pageSize=9999 고치기
+function useApplication(projectId) {
+  const { data, error, mutate } = useSWR(
+    projectId ? `/applications?pageSize=9999&pageNumber=1&projectId=${projectId}` : null,
+    authFetcher
+  );
+
+  return {
+    data,
+    error,
+    loading: !data && !error,
+    mutate,
+  };
+}
+
+export default useApplication;

--- a/frontend/src/components/pages/recruitments/ApplicantList.js
+++ b/frontend/src/components/pages/recruitments/ApplicantList.js
@@ -1,0 +1,135 @@
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+import {
+  Avatar,
+  Button,
+  HStack,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import useApplication from "components/hooks/useApplication";
+import Link from "next/link";
+import { useCallback } from "react";
+import { getAuthHeader } from "utils/auth";
+import { serverAxios } from "utils/axios";
+
+const STATUS = {
+  waiting: "대기",
+  approved: "승인",
+  rejected: "거절",
+};
+
+function ApplicantList({ projectId }) {
+  const { data, mutate, loading } = useApplication(projectId);
+
+  const handleClickManageButton = useCallback(
+    async (applicationId, status) => {
+      try {
+        await serverAxios.patch(
+          `/applications/${applicationId}`,
+          { projectId, status },
+          getAuthHeader()
+        );
+        mutate();
+      } catch (e) {
+        console.log(e);
+      }
+    },
+    [projectId, mutate]
+  );
+
+  if (loading) return "loading...";
+  return (
+    <TableContainer w="100%">
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>신청자</Th>
+            <Th textAlign="end" w="100px">
+              상태
+            </Th>
+            <Th textAlign="end" w="200px">
+              관리
+            </Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {data.content.length === 0 ? (
+            <Tr>
+              <Td colSpan={3}>신청자가 없습니다.</Td>
+            </Tr>
+          ) : (
+            data.content.map((application) => (
+              <Tr key={application.id}>
+                <Td>
+                  <Link href={`/users/${application.author.id}`} passHref>
+                    <Button
+                      as="a"
+                      target="_blank"
+                      variant="ghost"
+                      colorScheme="gray"
+                      columnGap="12px"
+                    >
+                      <Avatar size="sm" src={application.author.photoUrl} />
+                      <Text>{application.author.name}</Text>
+                      <ExternalLinkIcon />
+                    </Button>
+                  </Link>
+                </Td>
+                <Td textAlign="end">{STATUS[application.status]}</Td>
+                <Td textAlign="end">
+                  {application.status === "waiting" && (
+                    <>
+                      <Button
+                        size="sm"
+                        marginRight="8px"
+                        onClick={() => handleClickManageButton(application.id, "approved")}
+                      >
+                        승인
+                      </Button>
+                      <Button
+                        size="sm"
+                        colorScheme="red"
+                        onClick={() => handleClickManageButton(application.id, "rejected")}
+                      >
+                        거절
+                      </Button>
+                    </>
+                  )}
+                  {application.status === "approved" && (
+                    <Button
+                      size="sm"
+                      marginRight="8px"
+                      onClick={() => handleClickManageButton(application.id, "waiting")}
+                      variant="outline"
+                    >
+                      승인 취소
+                    </Button>
+                  )}
+                  {application.status === "rejected" && (
+                    <Button
+                      size="sm"
+                      marginRight="8px"
+                      onClick={() => handleClickManageButton(application.id, "waiting")}
+                      variant="outline"
+                      colorScheme="red"
+                    >
+                      거절 취소
+                    </Button>
+                  )}
+                </Td>
+              </Tr>
+            ))
+          )}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default ApplicantList;

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -26,6 +26,7 @@ import {
 } from "@chakra-ui/react";
 import useMe from "components/hooks/useMe";
 import useRecruitment from "components/hooks/useRecruitment";
+import ApplicantList from "components/pages/recruitments/ApplicantList";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -258,7 +259,10 @@ function RecruitmentDetailSection() {
 
           {loggedIn ? (
             mine ? (
-              <Button size="lg">신청자 확인하기</Button>
+              <>
+                <Divider />
+                <ApplicantList projectId={router.query.id} />
+              </>
             ) : (
               <>
                 {data.userApplication.isApplied ? (

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -86,6 +86,24 @@ function RecruitmentDetailSection() {
     }
   }, [router, mutate]);
 
+  const handleClickApplicationButton = useCallback(async () => {
+    try {
+      await serverAxios.post(`/applications`, { projectId: router.query.id }, getAuthHeader());
+      mutate();
+    } catch (e) {
+      console.log(e);
+    }
+  }, [router, mutate]);
+
+  const handleClickApplicationCancelButton = useCallback(async () => {
+    try {
+      await serverAxios.delete(`/applications/${data.userApplication.id}`, getAuthHeader());
+      mutate();
+    } catch (e) {
+      console.log(e);
+    }
+  }, [mutate, data]);
+
   if (loading) return "loading...";
   return (
     <Box as="section" marginTop="80px">
@@ -242,7 +260,17 @@ function RecruitmentDetailSection() {
             mine ? (
               <Button size="lg">신청자 확인하기</Button>
             ) : (
-              <Button size="lg">신청하기</Button>
+              <>
+                {data.userApplication.isApplied ? (
+                  <Button size="lg" colorScheme="red" onClick={handleClickApplicationCancelButton}>
+                    신청 취소
+                  </Button>
+                ) : (
+                  <Button size="lg" onClick={handleClickApplicationButton}>
+                    신청하기
+                  </Button>
+                )}
+              </>
             )
           ) : (
             <></>

--- a/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
+++ b/frontend/src/components/pages/recruitments/sections/RecruitmentDetailSection.js
@@ -55,6 +55,10 @@ function RecruitmentDetailSection() {
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  const { data, loading, mutate } = useRecruitment(router.query.id);
+  const { loggedIn, user } = useMe();
+  const mine = user?.userId === data?.author.id ?? false;
+
   const handleClickDeleteButton = useCallback(async () => {
     try {
       await serverAxios.delete(`/projects/${router.query.id}`, getAuthHeader());
@@ -64,9 +68,23 @@ function RecruitmentDetailSection() {
     }
   }, [router]);
 
-  const { data, loading } = useRecruitment(router.query.id);
-  const { loggedIn, user } = useMe();
-  const mine = user?.userId === data?.author.id ?? false;
+  const handleClickFavoriteButton = useCallback(async () => {
+    try {
+      await serverAxios.post(`/projects/${router.query.id}/favorite`, {}, getAuthHeader());
+      mutate();
+    } catch (e) {
+      console.log(e);
+    }
+  }, [router, mutate]);
+
+  const handleClickUnfavoriteButton = useCallback(async () => {
+    try {
+      await serverAxios.delete(`/projects/${router.query.id}/favorite`, getAuthHeader());
+      mutate();
+    } catch (e) {
+      console.log(e);
+    }
+  }, [router, mutate]);
 
   if (loading) return "loading...";
   return (
@@ -119,9 +137,25 @@ function RecruitmentDetailSection() {
                     </Modal>
                   </HStack>
                 ) : (
-                  <Button colorScheme="gray" variant="outline">
-                    즐겨찾기 등록
-                  </Button>
+                  <>
+                    {data.isFavorite ? (
+                      <Button
+                        colorScheme="gray"
+                        variant="outline"
+                        onClick={handleClickUnfavoriteButton}
+                      >
+                        즐겨찾기 해제
+                      </Button>
+                    ) : (
+                      <Button
+                        colorScheme="gray"
+                        variant="outline"
+                        onClick={handleClickFavoriteButton}
+                      >
+                        즐겨찾기 등록
+                      </Button>
+                    )}
+                  </>
                 )
               ) : (
                 <></>


### PR DESCRIPTION
## 작업 내용

### 백엔드
- 즐겨찾기 해제 (`DELETE /projects/:id/favorite`) 에서 필드 명이 잘못되어있던 것을 수정합니다.

### 프론트엔드
- 즐겨찾기 기능 (등록, 취소)
- 신청하기 기능 (등록, 취소)
- 신청자 관리 기능 (신청자 목록 테이블, 승인, 거절, 승인 취소, 거절 취소)

## 체크 리스트

- [x] 제목을 적절히 작성했나요?
- [x] 라벨을 알맞게 설정했나요?
